### PR TITLE
Custom rendering test

### DIFF
--- a/src/charts.rs
+++ b/src/charts.rs
@@ -1,2 +1,3 @@
 pub mod candlesticks;
 pub mod heatmap;
+pub mod custom_line;

--- a/src/charts/custom_line.rs
+++ b/src/charts/custom_line.rs
@@ -160,17 +160,23 @@ impl CustomLine {
             .width(Length::FillPortion(10))
             .height(Length::FillPortion(10));
     
-        let axis_labels_x = Canvas::new(AxisLabelXCanvas { labels_cache: &self.x_labels_cache, min: self.x_min_time, max: self.x_max_time })
+        let axis_labels_x = Canvas::new(
+            AxisLabelXCanvas { 
+                labels_cache: &self.x_labels_cache, min: self.x_min_time, max: self.x_max_time 
+            })
             .width(Length::FillPortion(10))
-            .height(Length::Fixed(40.0));
+            .height(Length::Fixed(25.0));
     
-        let axis_labels_y = Canvas::new(AxisLabelYCanvas { labels_cache: &self.y_labels_cache, min: self.y_min_price, max: self.y_max_price })
+        let axis_labels_y = Canvas::new(
+            AxisLabelYCanvas { 
+                labels_cache: &self.y_labels_cache, min: self.y_min_price, max: self.y_max_price 
+            })
             .width(Length::Fixed(40.0))
             .height(Length::FillPortion(10));
     
         let empty_space = Container::new(Space::new(Length::Fixed(40.0), Length::Fixed(40.0)))
             .width(Length::Fixed(40.0))
-            .height(Length::Fixed(40.0));
+            .height(Length::Fixed(25.0));
     
         let chart_and_y_labels = Row::new()
             .push(chart)
@@ -381,7 +387,7 @@ impl canvas::Program<Message> for CustomLine {
                             Point::new(x_position as f32, 0.0), 
                             Point::new(x_position as f32, bounds.height as f32)
                         );
-                        frame.stroke(&line, Stroke::default().with_color(Color::from_rgba(120.0, 120.0, 120.0, 0.1)).with_width(1.0));
+                        frame.stroke(&line, Stroke::default().with_color(Color::from_rgba8(40, 40, 40, 1.0)).with_width(1.0))
                     }
                     
                     time = time + time_step;
@@ -397,7 +403,7 @@ impl canvas::Program<Message> for CustomLine {
                         Point::new(0.0, y_position), 
                         Point::new(bounds.width as f32, y_position)
                     );
-                    frame.stroke(&line, Stroke::default().with_color(Color::from_rgba(80.0, 80.0, 80.0, 0.1)).with_width(1.0));
+                    frame.stroke(&line, Stroke::default().with_color(Color::from_rgba8(40, 40, 40, 1.0)).with_width(1.0));
                     y += step;
                 }
             });
@@ -571,9 +577,9 @@ impl canvas::Program<Message> for AxisLabelXCanvas<'_> {
                         let text_size = 12.0;
                         let label = canvas::Text {
                             content: time.format("%H:%M").to_string(),
-                            position: Point::new(x_position as f32 - text_size / 2.0, bounds.height as f32 - 20.0),
+                            position: Point::new(x_position as f32 - text_size, bounds.height as f32 - 20.0),
                             size: iced::Pixels(text_size),
-                            color: Color::WHITE,
+                            color: Color::from_rgba8(200, 200, 200, 1.0),
                             ..canvas::Text::default()
                         };  
 
@@ -596,7 +602,15 @@ impl canvas::Program<Message> for AxisLabelXCanvas<'_> {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {
-        mouse::Interaction::default()
+        match interaction {
+            Interaction::Drawing => mouse::Interaction::Crosshair,
+            Interaction::Erasing => mouse::Interaction::Crosshair,
+            Interaction::Panning { .. } => mouse::Interaction::ResizingHorizontally,
+            Interaction::None if cursor.is_over(bounds) => {
+                mouse::Interaction::ResizingHorizontally
+            }
+            Interaction::None => mouse::Interaction::default(),
+        }
     }
 }
 pub struct AxisLabelYCanvas<'a> {
@@ -648,7 +662,7 @@ impl canvas::Program<Message> for AxisLabelYCanvas<'_> {
                         content: format!("{:.1}", y),
                         position: Point::new(5.0, y_position - text_size / 2.0),
                         size: iced::Pixels(text_size),
-                        color: Color::WHITE,
+                        color: Color::from_rgba8(200, 200, 200, 1.0),
                         ..canvas::Text::default()
                     };  
 
@@ -669,6 +683,14 @@ impl canvas::Program<Message> for AxisLabelYCanvas<'_> {
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {
-        mouse::Interaction::default()
+        match interaction {
+            Interaction::Drawing => mouse::Interaction::Crosshair,
+            Interaction::Erasing => mouse::Interaction::Crosshair,
+            Interaction::Panning { .. } => mouse::Interaction::ResizingVertically,
+            Interaction::None if cursor.is_over(bounds) => {
+                mouse::Interaction::ResizingVertically
+            }
+            Interaction::None => mouse::Interaction::default(),
+        }
     }
 }

--- a/src/charts/custom_line.rs
+++ b/src/charts/custom_line.rs
@@ -1,0 +1,349 @@
+use std::collections::BTreeMap;
+use chrono::{DateTime, Utc, Duration, TimeZone, LocalResult};
+use iced::mouse;
+use iced::widget::canvas;
+use iced::widget::canvas::event::{self, Event};
+use iced::widget::canvas::stroke::{self, Stroke};
+use iced::widget::canvas::{Cache, Geometry, Path, Canvas};
+use iced::window;
+use iced::{
+    Color, Point, Rectangle, Renderer, Size,
+    Theme, Vector, Element, Length
+};
+use std::future::Future;
+use crate::market_data::Kline;
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Translated(Vector),
+    Scaled(f32, Option<Vector>),
+}
+
+#[derive(Debug)]
+pub struct CustomLine {
+    space_cache: Cache,
+    system_cache: Cache,
+    translation: Vector,
+    scaling: f32,
+    klines_raw: BTreeMap<DateTime<Utc>, (f32, f32, f32, f32)>,
+    autoscale: bool,
+}
+impl CustomLine {
+    const MIN_SCALING: f32 = 0.1;
+    const MAX_SCALING: f32 = 2.0;
+
+    pub fn new(_klines: Vec<Kline>, _timeframe_in_minutes: i16) -> CustomLine {
+        let _size = window::Settings::default().size;
+        CustomLine {
+            space_cache: canvas::Cache::default(),
+            system_cache: canvas::Cache::default(),
+            klines_raw: BTreeMap::new(),
+            translation: Vector::default(),
+            scaling: 1.0,
+            autoscale: false,
+        }
+    }
+
+    pub fn set_dataset(&mut self, klines: Vec<Kline>) {
+        self.klines_raw.clear();
+
+        for kline in klines {
+            let time = match Utc.timestamp_opt(kline.time as i64 / 1000, 0) {
+                LocalResult::Single(dt) => dt,
+                _ => continue, 
+            };
+            let open = kline.open;
+            let high = kline.high;
+            let low = kline.low;
+            let close = kline.close;
+            self.klines_raw.insert(time, (open, high, low, close));
+        }
+
+        self.system_cache.clear();
+    }
+
+    pub fn insert_datapoint(&mut self, kline: Kline) {
+        let time = match Utc.timestamp_opt(kline.time as i64 / 1000, 0) {
+            LocalResult::Single(dt) => dt,
+            _ => return, 
+        };
+        let open = kline.open;
+        let high = kline.high;
+        let low = kline.low;
+        let close = kline.close;
+        self.klines_raw.insert(time, (open, high, low, close));
+
+        self.system_cache.clear();
+    }
+    
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::Translated(translation) => {
+                if self.autoscale {
+                    self.translation.x = translation.x;
+                } else {
+                    self.translation = translation;
+                }
+
+                self.system_cache.clear();
+                self.space_cache.clear();
+            }
+            Message::Scaled(scaling, translation) => {
+                self.scaling = scaling;
+                
+                if let Some(translation) = translation {
+                    if self.autoscale {
+                        self.translation.x = translation.x;
+                    } else {
+                        self.translation = translation;
+                    }
+                }
+
+                self.system_cache.clear();
+                self.space_cache.clear();
+            }
+        }
+    }
+
+    pub fn view(&self) -> Element<Message> {
+        Canvas::new(self)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .into()
+    }
+}
+
+
+#[derive(Debug, Clone, Copy)]
+pub enum Interaction {
+    None,
+    Drawing,
+    Erasing,
+    Panning { translation: Vector, start: Point },
+}
+
+impl Default for Interaction {
+    fn default() -> Self {
+        Self::None
+    }
+}
+impl canvas::Program<Message> for CustomLine {
+    type State = Interaction;
+
+    fn update(
+        &self,
+        interaction: &mut Interaction,
+        event: Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> (event::Status, Option<Message>) {
+        if let Event::Mouse(mouse::Event::ButtonReleased(_)) = event {
+            *interaction = Interaction::None;
+        }
+
+        let Some(cursor_position) = cursor.position_in(bounds) else {
+            return (event::Status::Ignored, None);
+        };
+
+        match event {
+            Event::Mouse(mouse_event) => match mouse_event {
+                mouse::Event::ButtonPressed(button) => {
+                    let message = match button {
+                        mouse::Button::Right => {
+                            *interaction = Interaction::Drawing;
+                            None
+                        }
+                        mouse::Button::Left => {
+                            *interaction = Interaction::Panning {
+                                translation: self.translation,
+                                start: cursor_position,
+                            };
+                            None
+                        }
+                        _ => None,
+                    };
+
+                    (event::Status::Captured, message)
+                }
+                mouse::Event::CursorMoved { .. } => {
+                    let message = match *interaction {
+                        Interaction::Drawing => None,
+                        Interaction::Erasing => None,
+                        Interaction::Panning { translation, start } => {
+                            Some(Message::Translated(
+                                translation
+                                    + (cursor_position - start)
+                                        * (1.0 / self.scaling),
+                            ))
+                        }
+                        Interaction::None => None,
+                    };
+
+                    let event_status = match interaction {
+                        Interaction::None => event::Status::Ignored,
+                        _ => event::Status::Captured,
+                    };
+
+                    (event_status, message)
+                }
+                mouse::Event::WheelScrolled { delta } => match delta {
+                    mouse::ScrollDelta::Lines { y, .. }
+                    | mouse::ScrollDelta::Pixels { y, .. } => {
+                        if y < 0.0 && self.scaling > Self::MIN_SCALING
+                            || y > 0.0 && self.scaling < Self::MAX_SCALING
+                        {
+                            let old_scaling = self.scaling;
+
+                            let scaling = (self.scaling * (1.0 + y / 30.0))
+                                .clamp(
+                                    Self::MIN_SCALING,
+                                    Self::MAX_SCALING,
+                                );
+
+                            let translation =
+                                if let Some(cursor_to_center) =
+                                    cursor.position_from(bounds.center())
+                                {
+                                    let factor = scaling - old_scaling;
+
+                                    Some(
+                                        self.translation
+                                            - Vector::new(
+                                                cursor_to_center.x * factor
+                                                    / (old_scaling
+                                                        * old_scaling),
+                                                cursor_to_center.y * factor
+                                                    / (old_scaling
+                                                        * old_scaling),
+                                            ),
+                                    )
+                                } else {
+                                    None
+                                };
+
+                            (
+                                event::Status::Captured,
+                                Some(Message::Scaled(scaling, translation)),
+                            )
+                        } else {
+                            (event::Status::Captured, None)
+                        }
+                    }
+                },
+                _ => (event::Status::Ignored, None),
+            },
+            _ => (event::Status::Ignored, None),
+        }
+    }
+    
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let default_time = Utc::now();
+        let latest: i64 = self.klines_raw.keys().last().unwrap_or_else(||&default_time).timestamp() as i64;
+        let earliest: i64 = latest - 6400;
+
+        let x_range = latest - earliest;
+
+        let mut highest = f32::MIN;
+        let mut lowest = f32::MAX;
+        for (time, (_, high, low, _)) in &self.klines_raw {
+            if *high > highest {
+                highest = *high;
+            }
+            if *low < lowest {
+                lowest = *low;
+            }
+        }
+        let y_range = highest - lowest;
+
+        let background = 
+            self.space_cache.draw(renderer, bounds.size(), |frame| {
+                let text_size = 14.0;
+                let highest_label = canvas::Text {
+                    content: format!("{:.2}", highest),
+                    position: Point::new(0.0, 0.0),
+                    size: iced::Pixels(text_size),
+                    color: Color::WHITE,
+                    ..canvas::Text::default()
+                };            
+                let lowest_label = canvas::Text {
+                    content: format!("{:.2}", lowest),
+                    position: Point::new(0.0, bounds.height - (text_size + text_size / 2.0)),
+                    size: iced::Pixels(text_size),
+                    color: Color::WHITE,
+                    ..canvas::Text::default()
+                };
+                highest_label.draw_with(|path, color| {
+                    frame.fill(&path, color);
+                });
+                lowest_label.draw_with(|path, color| {
+                    frame.fill(&path, color);
+                });
+            });
+
+        let center = Vector::new(bounds.width / 2.0, bounds.height / 2.0);
+
+        let candlesticks = 
+            self.system_cache.draw(renderer, bounds.size(), |frame| {
+                frame.with_save(|frame| {
+                    frame.translate(center);
+                    frame.scale(self.scaling);
+                    frame.translate(self.translation);
+
+                    for (time, (open, high, low, close)) in &self.klines_raw {
+                        let x_position: f64 = ((time.timestamp() - earliest) as f64 / x_range as f64) * bounds.width as f64;
+                        
+                        let y_open = bounds.height - ((open - lowest) / y_range * bounds.height);
+                        let y_high = bounds.height - ((high - lowest) / y_range * bounds.height);
+                        let y_low = bounds.height - ((low - lowest) / y_range * bounds.height);
+                        let y_close = bounds.height - ((close - lowest) / y_range * bounds.height);
+                        
+                        let color = if close > open { Color::from_rgb8(81, 205, 160) } else { Color::from_rgb8(192, 80, 77) };
+    
+                        let body = Path::rectangle(
+                            Point::new(x_position as f32 - (2.0), y_open.min(y_close)), 
+                            Size::new(4.0, (y_open - y_close).abs())
+                        );                    
+                        frame.fill(&body, color);
+                        
+                        let wick = Path::line(
+                            Point::new(x_position as f32, y_high), 
+                            Point::new(x_position as f32, y_low)
+                        );
+                        frame.stroke(&wick, Stroke::default().with_color(color).with_width(1.0));
+                    }
+                });
+            });
+
+        vec![background, candlesticks]
+    }
+
+    fn mouse_interaction(
+        &self,
+        interaction: &Interaction,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        match interaction {
+            Interaction::Drawing => mouse::Interaction::Crosshair,
+            Interaction::Erasing => mouse::Interaction::Crosshair,
+            Interaction::Panning { .. } => mouse::Interaction::Grabbing,
+            Interaction::None if cursor.is_over(bounds) => {
+                mouse::Interaction::Crosshair
+            }
+            Interaction::None => mouse::Interaction::default(),
+        }
+    }
+}
+
+impl Default for CustomLine {
+    fn default() -> Self {
+        Self::new(vec![], 1)
+    }
+}

--- a/src/data_providers/binance/market_data.rs
+++ b/src/data_providers/binance/market_data.rs
@@ -244,7 +244,7 @@ impl From<FetchedKlines> for Kline {
     }
 }
 pub async fn fetch_klines(ticker: String, timeframe: String) -> Result<Vec<Kline>, reqwest::Error> {
-    let url = format!("https://fapi.binance.com/fapi/v1/klines?symbol={}&interval={}&limit=180", ticker.to_lowercase(), timeframe);
+    let url = format!("https://fapi.binance.com/fapi/v1/klines?symbol={}&interval={}&limit=720", ticker.to_lowercase(), timeframe);
     let response = reqwest::get(&url).await?;
     let value: serde_json::Value = response.json().await?;
     let fetched_klines: Result<Vec<FetchedKlines>, _> = serde_json::from_value(value);

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,6 +149,7 @@ impl Default for UserWsState {
 pub enum PaneId {
     HeatmapChart,
     CandlestickChart,
+    CustomChart,
     TimeAndSales,
     TradePanel,
 }
@@ -238,7 +239,7 @@ struct State {
     trades_chart: Option<heatmap::LineChart>,
     candlestick_chart: Option<candlesticks::CandlestickChart>,
     time_and_sales: Option<TimeAndSales>,
-    custom_line: CustomLine,
+    custom_line: Option<CustomLine>,
 
     // data streams
     listen_key: Option<String>,
@@ -307,7 +308,7 @@ impl Application for State {
                 trades_chart: None,
                 candlestick_chart: None,
                 time_and_sales: None,
-                custom_line: CustomLine::default(),
+                custom_line: None,
                 listen_key: None,
                 selected_ticker: None,
                 selected_timeframe: Some(Timeframe::M1),
@@ -398,7 +399,9 @@ impl Application for State {
     fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
         match message {
             Message::CustomLine(message) => {
-                self.custom_line.update(message);
+                if let Some(custom_line) = &mut self.custom_line {
+                    custom_line.update(message);
+                }
                 Command::none()
             },
 
@@ -537,6 +540,7 @@ impl Application for State {
                     self.trades_chart = None;
                     self.candlestick_chart = None;
                     self.time_and_sales = None;
+                    self.custom_line = None;
 
                     self.open_orders.clear();
                     self.orders_rows.clear();
@@ -567,7 +571,7 @@ impl Application for State {
 
                         self.candlestick_chart = Some(CandlestickChart::new(klines, timeframe_in_minutes));
 
-                        self.custom_line.set_dataset(klines_clone);
+                        self.custom_line = Some(CustomLine::new(klines_clone, timeframe_in_minutes))
                     },
                     Err(err) => {
                         eprintln!("Error fetching klines: {}", err);
@@ -599,7 +603,9 @@ impl Application for State {
                             chart.update(kline);
                         }
                         
-                        self.custom_line.insert_datapoint(kline_clone);
+                        if let Some(custom_line) = &mut self.custom_line {
+                            custom_line.insert_datapoint(kline_clone);
+                        }
                     }
                 };
                 Command::none()
@@ -739,6 +745,9 @@ impl Application for State {
                         },
                         PaneId::CandlestickChart => {
                             self.panes_open.insert(PaneId::CandlestickChart, false);
+                        },
+                        PaneId::CustomChart => {
+                            self.panes_open.insert(PaneId::CustomChart, false);
                         },
                         PaneId::TimeAndSales => {
                             self.panes_open.insert(PaneId::TimeAndSales, false);
@@ -1018,6 +1027,7 @@ impl Application for State {
             let title = match pane.id {
                 PaneId::HeatmapChart => "Heatmap Chart",
                 PaneId::CandlestickChart => "Candlestick Chart",
+                PaneId::CustomChart => "Custom Chart",
                 PaneId::TimeAndSales => "Time & Sales",
                 PaneId::TradePanel => "Trading Panel",
             };            
@@ -1066,6 +1076,7 @@ impl Application for State {
                 menu_tpl_1(menu_items!(
                     (debug_button(PaneId::HeatmapChart, self.panes_open.get(&PaneId::HeatmapChart).unwrap_or(&false), self.first_pane))
                     (debug_button(PaneId::CandlestickChart, self.panes_open.get(&PaneId::CandlestickChart).unwrap_or(&false), self.first_pane))
+                    (debug_button(PaneId::CustomChart, self.panes_open.get(&PaneId::CustomChart).unwrap_or(&false), self.first_pane))
                     (debug_button(PaneId::TimeAndSales, self.panes_open.get(&PaneId::TimeAndSales).unwrap_or(&false), self.first_pane))
                     (debug_button(PaneId::TradePanel, self.panes_open.get(&PaneId::TradePanel).unwrap_or(&false), self.first_pane))
                 )).width(200.0)
@@ -1209,7 +1220,7 @@ fn view_content<'a, 'b: 'a>(
     time_and_sales: &'a Option<TimeAndSales>,
     trades_chart: &'a Option<LineChart>,
     candlestick_chart: &'a Option<CandlestickChart>,
-    custom_line: &'a CustomLine,
+    custom_line: &'a Option<CustomLine>,
     qty_input_val: Option<String>,
     price_input_val: Option<String>, 
     orders_header: &'b scrollable::Id,
@@ -1294,6 +1305,47 @@ fn view_content<'a, 'b: 'a>(
                 .align_y(alignment::Vertical::Center)
                 .into()
         },
+
+        PaneId::CustomChart => { 
+            let underlay; 
+            if let Some(custom_line) = custom_line {
+                underlay =
+                    custom_line
+                        .view()
+                        .map(move |message| Message::CustomLine(message));
+            } else {
+                underlay = Text::new("No data").into();
+            }
+
+            let overlay = if show_modal {
+                Some(
+                    Card::new(
+                        Text::new("Custom Chart -> Settings"),
+                        Column::new()
+                            .push(Text::new("Test"))
+                    )
+                    .foot(
+                        Row::new()
+                            .spacing(10)
+                            .padding(5)
+                            .width(Length::Fill)
+                            .push(
+                                Text::new("Footer").size(16)
+                            )
+                    )
+                    .max_width(500.0)
+                    .on_close(Message::CloseModal)
+                )
+            } else {
+                None
+            };
+
+            modal(underlay, overlay)
+                .backdrop(Message::CloseModal)
+                .on_esc(Message::CloseModal)
+                .align_y(alignment::Vertical::Center)
+                .into()
+        },
         
         PaneId::TimeAndSales => { 
             let underlay = time_and_sales.as_ref().map(TimeAndSales::view).unwrap_or_else(|| Text::new("No data").into()); 
@@ -1337,10 +1389,7 @@ fn view_content<'a, 'b: 'a>(
         },  
         
         PaneId::TradePanel => if account_info_usdt.is_none() {
-            custom_line
-                .view()
-                .map(move |message| Message::CustomLine(message))
-                .into()
+            Text::new("No account info found").into()
         } else {
             let form_select_0_button = button("Market Order")
                 .on_press(Message::TabSelected(0, "order_form".to_string()));


### PR DESCRIPTION
Had to implement custom rendered chart using Iced's Canvas, as Plotters didn't allow much customization as in a future-proof way, and also had some issues on styling.

This new candlestick chart now features panning and zooming, while maintaining dynamic axes labels and responsivity.

![image](https://github.com/akenshaw/iced-trade/assets/63060680/347a5a46-18a1-417b-b008-e5ceb2874330)
