### PR TITLE
Bybit linear perps integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1875,7 @@ dependencies = [
 name = "iced-trade"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-tungstenite",
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ hex = "0.4.3"
 iced_table = "0.12.0"
 iced_futures = "0.12.0"
 iced_aw = { version = "0.8.0", features = ["quad", "menu"] }
+anyhow = "1.0.86"
 [dependencies.async-tungstenite]
 version = "0.25"
 features = ["tokio-rustls-webpki-roots"]

--- a/src/charts/footprint.rs
+++ b/src/charts/footprint.rs
@@ -55,7 +55,7 @@ impl Footprint {
         }
         for trade in trades_raw {
             let rounded_time = (trade.time / aggregate_time) * aggregate_time;
-            let price_level = (trade.price / tick_size).round() as i64 * (tick_size * 100.0) as i64;
+            let price_level: i64 = (trade.price * (1.0 / tick_size)).round() as i64;
 
             let entry: &mut (HashMap<i64, (f32, f32)>, (f32, f32, f32, f32, f32, f32)) = data_points
                 .entry(rounded_time)

--- a/src/data_providers.rs
+++ b/src/data_providers.rs
@@ -1,1 +1,2 @@
 pub mod binance;
+pub mod bybit;

--- a/src/data_providers/bybit.rs
+++ b/src/data_providers/bybit.rs
@@ -1,0 +1,1 @@
+pub mod market_data;

--- a/src/main.rs
+++ b/src/main.rs
@@ -494,7 +494,7 @@ impl State {
                                                     low: kline.low,
                                                     close: kline.close,
                                                     volume: kline.volume,
-                                                    taker_buy_base_asset_volume: 1.0,
+                                                    taker_buy_base_asset_volume: -1.0,
                                                 }
                                             }).collect();
 
@@ -587,7 +587,7 @@ impl State {
                                                             low: kline.low,
                                                             close: kline.close,
                                                             volume: kline.volume,
-                                                            taker_buy_base_asset_volume: 1.0,
+                                                            taker_buy_base_asset_volume: -1.0,
                                                         }
                                                     }).collect();
 
@@ -775,7 +775,7 @@ impl State {
                                             low: kline.low,
                                             close: kline.close,
                                             volume: kline.volume,
-                                            taker_buy_base_asset_volume: 1.0,
+                                            taker_buy_base_asset_volume: -1.0,
                                         };
 
                                         match pane_state.id {


### PR DESCRIPTION
It seems, or I couldn't find it idk, Bybit doesn't publish buy/sell volumes separately in their kline data streams/getters. They just publish it summed up under "volume". This has been a little issue as this wasn't the case for Binance and some parts of charts were built upon considering that.  

With that, and also not thinking integrating another exchange while handling Binance back in the day, lots of dirty work going on in this branch